### PR TITLE
Handle secrets in browser environments

### DIFF
--- a/public/components/AIAssistant.tsx
+++ b/public/components/AIAssistant.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { GoogleGenAI, Chat } from '@google/genai';
 import type { PackageTier, AlaCarteOption } from '../types';
+import { getEnvValue } from '../env';
 
 interface AIAssistantProps {
   packages: PackageTier[];
@@ -66,8 +67,7 @@ export const AIAssistant: React.FC<AIAssistantProps> = ({ packages, alaCarteOpti
 
     setError(null);
     setMessages([{ role: 'model', text: 'Hello! I am the Priority Lexus AI Assistant. How can I help you choose the perfect protection for your vehicle today?' }]);
-    // Fix: Use process.env.API_KEY as required by the guidelines.
-    const apiKey = process.env.API_KEY;
+    const apiKey = getEnvValue('API_KEY');
 
     if (!apiKey) {
       setError("The AI Assistant is not configured. Please add the API_KEY to the application's secrets.");

--- a/public/env.ts
+++ b/public/env.ts
@@ -1,0 +1,43 @@
+type EnvLike = Record<string, string | undefined> | undefined;
+
+const getProcessEnv = (): EnvLike => {
+  if (typeof process !== 'undefined' && typeof process.env === 'object') {
+    return process.env as EnvLike;
+  }
+  return undefined;
+};
+
+const getImportMetaEnv = (): EnvLike => {
+  try {
+    const meta = (import.meta as { env?: EnvLike })?.env;
+    return meta;
+  } catch (_error) {
+    return undefined;
+  }
+};
+
+const getGlobalSecrets = (): EnvLike => {
+  if (typeof globalThis !== 'undefined') {
+    const globalAny = globalThis as Record<string, unknown>;
+    const possibleKeys = ['secrets', 'env', '__env__'];
+    for (const key of possibleKeys) {
+      const value = globalAny[key];
+      if (value && typeof value === 'object') {
+        return value as EnvLike;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const getEnvValue = (key: string): string | undefined => {
+  const sources = [getProcessEnv, getImportMetaEnv, getGlobalSecrets];
+  for (const getSource of sources) {
+    const source = getSource();
+    if (source && typeof source[key] === 'string') {
+      return source[key];
+    }
+  }
+  return undefined;
+};
+

--- a/public/firebase.ts
+++ b/public/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp, FirebaseApp } from 'firebase/app';
 import { getFirestore, Firestore } from 'firebase/firestore/lite';
 import { getAuth, Auth } from 'firebase/auth';
+import { getEnvValue } from './env';
 
 let app: FirebaseApp | null = null;
 let db: Firestore | null = null;
@@ -8,26 +9,42 @@ let auth: Auth | null = null;
 let firebaseInitializationError: string | null = null;
 
 try {
-  // Standardize on FIREBASE_CONFIG to be consistent with API_KEY convention.
-  const firebaseConfigStr = process.env.FIREBASE_CONFIG;
-  if (!firebaseConfigStr || firebaseConfigStr === '""') {
-    firebaseInitializationError = "Firebase configuration is missing. Please go to the 'Secrets' tab (key icon 🔑) and set FIREBASE_CONFIG with the configuration object from your Firebase project's settings.";
+  const firebaseConfigStr = getEnvValue('FIREBASE_CONFIG');
+  let firebaseConfig = null;
+  if (firebaseConfigStr) {
+    try {
+      firebaseConfig = JSON.parse(firebaseConfigStr);
+    } catch (error) {
+      console.error('Failed to parse FIREBASE_CONFIG env value:', error);
+      firebaseInitializationError = 'Failed to parse FIREBASE_CONFIG. Ensure it is valid JSON.';
+    }
+  }
+
+  if (!firebaseConfig || !firebaseConfig.apiKey || !firebaseConfig.projectId) {
+    const apiKey = getEnvValue('FIREBASE_API_KEY');
+    const projectId = getEnvValue('FIREBASE_PROJECT_ID');
+    const authDomain = getEnvValue('FIREBASE_AUTH_DOMAIN');
+    const storageBucket = getEnvValue('FIREBASE_STORAGE_BUCKET');
+    const messagingSenderId = getEnvValue('FIREBASE_MESSAGING_SENDER_ID');
+    const appId = getEnvValue('FIREBASE_APP_ID');
+
+    if (apiKey && projectId && authDomain) {
+      firebaseConfig = {
+        apiKey,
+        projectId,
+        authDomain,
+        storageBucket,
+        messagingSenderId,
+        appId,
+      };
+    }
+  }
+
+  if (!firebaseConfig || !firebaseConfig.apiKey || !firebaseConfig.projectId) {
+    firebaseInitializationError = firebaseInitializationError ?? "Firebase configuration is missing or incomplete. Provide FIREBASE_CONFIG or the individual Firebase environment variables.";
     throw new Error(firebaseInitializationError);
   }
 
-  let firebaseConfig;
-  try {
-    firebaseConfig = JSON.parse(firebaseConfigStr);
-  } catch (e) {
-    firebaseInitializationError = "Failed to parse FIREBASE_CONFIG. Please ensure it's a valid JSON object copied from your Firebase project's settings.";
-    throw new Error(firebaseInitializationError);
-  }
-
-  if (!firebaseConfig.apiKey || !firebaseConfig.projectId) {
-    firebaseInitializationError = "The FIREBASE_CONFIG is incomplete. Please provide the full configuration object from your Firebase project.";
-    throw new Error(firebaseInitializationError);
-  }
-  
   app = initializeApp(firebaseConfig);
   db = getFirestore(app);
   auth = getAuth(app);

--- a/public/supabaseClient.ts
+++ b/public/supabaseClient.ts
@@ -1,7 +1,8 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEnvValue } from './env';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const supabaseUrl = getEnvValue('SUPABASE_URL');
+const supabaseAnonKey = getEnvValue('SUPABASE_ANON_KEY');
 
 let supabase: SupabaseClient | null = null;
 let supabaseInitializationError: string | null = null;

--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { GoogleGenAI, Chat } from '@google/genai';
 import type { PackageTier, AlaCarteOption } from '../types';
+import { getEnvValue } from '../env';
 
 interface AIAssistantProps {
   packages: PackageTier[];
@@ -66,7 +67,7 @@ export const AIAssistant: React.FC<AIAssistantProps> = ({ packages, alaCarteOpti
 
     setError(null);
     setMessages([{ role: 'model', text: 'Hello! I am the Priority Lexus AI Assistant. How can I help you choose the perfect protection for your vehicle today?' }]);
-    const apiKey = process.env.API_KEY;
+    const apiKey = getEnvValue('API_KEY');
 
     if (!apiKey) {
       setError("The AI Assistant is not configured. An API_KEY is required.");

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,57 @@
+/**
+ * Provides a consistent way to access environment variables across different
+ * runtimes (Vite during local development, Google AI Studio, plain browsers).
+ *
+ * Google AI Studio does not always expose a Node-style `process.env`. Some
+ * integrations surface secrets on `globalThis.secrets` or other global bags.
+ * By checking a handful of common locations we can gracefully read values
+ * without throwing reference errors in the browser.
+ */
+
+type EnvLike = Record<string, string | undefined> | undefined;
+
+const getProcessEnv = (): EnvLike => {
+  if (typeof process !== 'undefined' && typeof process.env === 'object') {
+    return process.env as EnvLike;
+  }
+  return undefined;
+};
+
+const getImportMetaEnv = (): EnvLike => {
+  try {
+    const meta = (import.meta as { env?: EnvLike })?.env;
+    return meta;
+  } catch (_error) {
+    return undefined;
+  }
+};
+
+const getGlobalSecrets = (): EnvLike => {
+  if (typeof globalThis !== 'undefined') {
+    const globalAny = globalThis as Record<string, unknown>;
+    const possibleKeys = ['secrets', 'env', '__env__'];
+    for (const key of possibleKeys) {
+      const value = globalAny[key];
+      if (value && typeof value === 'object') {
+        return value as EnvLike;
+      }
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Attempts to read an environment variable from several possible sources.
+ * Returns `undefined` when the variable is not set anywhere.
+ */
+export const getEnvValue = (key: string): string | undefined => {
+  const sources = [getProcessEnv, getImportMetaEnv, getGlobalSecrets];
+  for (const getSource of sources) {
+    const source = getSource();
+    if (source && typeof source[key] === 'string') {
+      return source[key];
+    }
+  }
+  return undefined;
+};
+

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,19 +1,52 @@
 import { initializeApp, FirebaseApp } from 'firebase/app';
 import { getFirestore, Firestore } from 'firebase/firestore/lite';
 import { getAuth, Auth } from 'firebase/auth';
+import { getEnvValue } from './env';
 
-/**
- * Client-side Firebase config via Vite envs.
- * Provide values in .env or .env.production with VITE_ prefix.
- */
-const firebaseConfig = {
-  apiKey: process.env.VITE_FIREBASE_API_KEY,
-  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.VITE_FIREBASE_APP_ID,
+interface FirebaseConfig {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket?: string;
+  messagingSenderId?: string;
+  appId?: string;
+}
+
+const buildFirebaseConfig = (): FirebaseConfig | null => {
+  const firebaseConfigStr = getEnvValue('FIREBASE_CONFIG');
+  if (firebaseConfigStr) {
+    try {
+      const parsed = JSON.parse(firebaseConfigStr) as FirebaseConfig;
+      if (parsed.apiKey && parsed.projectId) {
+        return parsed;
+      }
+    } catch (error) {
+      console.error('Failed to parse FIREBASE_CONFIG env value:', error);
+    }
+  }
+
+  const apiKey = getEnvValue('VITE_FIREBASE_API_KEY') ?? getEnvValue('FIREBASE_API_KEY');
+  const projectId = getEnvValue('VITE_FIREBASE_PROJECT_ID') ?? getEnvValue('FIREBASE_PROJECT_ID');
+  const authDomain = getEnvValue('VITE_FIREBASE_AUTH_DOMAIN') ?? getEnvValue('FIREBASE_AUTH_DOMAIN');
+  const storageBucket = getEnvValue('VITE_FIREBASE_STORAGE_BUCKET') ?? getEnvValue('FIREBASE_STORAGE_BUCKET');
+  const messagingSenderId = getEnvValue('VITE_FIREBASE_MESSAGING_SENDER_ID') ?? getEnvValue('FIREBASE_MESSAGING_SENDER_ID');
+  const appId = getEnvValue('VITE_FIREBASE_APP_ID') ?? getEnvValue('FIREBASE_APP_ID');
+
+  if (apiKey && projectId && authDomain) {
+    return {
+      apiKey,
+      projectId,
+      authDomain,
+      storageBucket,
+      messagingSenderId,
+      appId,
+    };
+  }
+
+  return null;
 };
+
+const firebaseConfig = buildFirebaseConfig();
 
 let app: FirebaseApp | null = null;
 let db: Firestore | null = null;
@@ -21,8 +54,8 @@ let auth: Auth | null = null;
 let firebaseInitializationError: string | null = null;
 
 try {
-  if (!firebaseConfig.apiKey || !firebaseConfig.projectId) {
-    throw new Error('Missing Firebase VITE_ env vars. Create a .env file and add the required values.');
+  if (!firebaseConfig) {
+    throw new Error('Missing Firebase configuration. Add FIREBASE_CONFIG or the individual Firebase environment variables.');
   }
   app = initializeApp(firebaseConfig);
   db = getFirestore(app);

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,7 +1,8 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEnvValue } from './env';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const supabaseUrl = getEnvValue('SUPABASE_URL');
+const supabaseAnonKey = getEnvValue('SUPABASE_ANON_KEY');
 
 let supabase: SupabaseClient | null = null;
 let supabaseInitializationError: string | null = null;


### PR DESCRIPTION
## Summary
- add an environment helper that safely reads secrets in browser and AI Studio runtimes
- update Firebase, Supabase, and AI Assistant modules to rely on the shared helper in both src and public builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f113994ccc8325986af9d2a3a6949c