### PR TITLE
feat: Add Firestore data import script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,9 @@
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@vitest/ui": "^4.0.10",
+        "dotenv": "^17.2.3",
         "jsdom": "^27.2.0",
+        "tsx": "^4.20.6",
         "vitest": "^4.0.10"
       },
       "engines": {
@@ -3167,6 +3169,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3746,6 +3761,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -5089,6 +5117,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5806,6 +5844,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "import-data": "tsx scripts/import-mock-data.ts"
   },
   "dependencies": {
     "@google/genai": "^0.12.0",
@@ -41,7 +42,9 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitest/ui": "^4.0.10",
+    "dotenv": "^17.2.3",
     "jsdom": "^27.2.0",
+    "tsx": "^4.20.6",
     "vitest": "^4.0.10"
   }
 }

--- a/scripts/import-mock-data.ts
+++ b/scripts/import-mock-data.ts
@@ -1,0 +1,108 @@
+/**
+ * Import mock data to Firestore
+ * Run with: npm run import-data
+ */
+
+import dotenv from 'dotenv';
+import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, addDoc, getDocs } from 'firebase/firestore/lite';
+import { MOCK_PACKAGES, MOCK_FEATURES, MOCK_ALA_CARTE_OPTIONS } from '../src/mock.js';
+
+// Load environment variables from .env.local
+dotenv.config({ path: '.env.local' });
+
+const firebaseConfig = {
+  apiKey: process.env.VITE_FIREBASE_API_KEY,
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VITE_FIREBASE_APP_ID,
+};
+
+if (!firebaseConfig.apiKey || !firebaseConfig.projectId) {
+  console.error('❌ Firebase configuration is missing!');
+  console.error('Make sure .env.local exists with VITE_FIREBASE_* variables.');
+  process.exit(1);
+}
+
+console.log('🔥 Initializing Firebase...');
+console.log(`📁 Project ID: ${firebaseConfig.projectId}\n`);
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+async function importData() {
+  try {
+    console.log('\n📊 Starting data import...\n');
+
+    // Import Features
+    console.log('📦 Importing features...');
+    const featuresCol = collection(db, 'features');
+    const existingFeatures = await getDocs(featuresCol);
+
+    if (existingFeatures.empty) {
+      const featureIds: Record<string, string> = {};
+
+      for (const feature of MOCK_FEATURES) {
+        const { id: mockId, ...featureData } = feature;
+        const docRef = await addDoc(featuresCol, featureData);
+        featureIds[mockId] = docRef.id;
+        console.log(`  ✓ Added feature: ${feature.name} (${docRef.id})`);
+      }
+
+      console.log(`\n✓ Imported ${MOCK_FEATURES.length} features\n`);
+
+      // Import Packages (with correct feature IDs)
+      console.log('📦 Importing packages...');
+      const packagesCol = collection(db, 'packages');
+
+      for (const pkg of MOCK_PACKAGES) {
+        const { id: mockId, features, ...packageData } = pkg;
+
+        // Map feature IDs from mock to actual Firestore IDs
+        const featureIds_array = features.map(f => {
+          const mockFeatureId = MOCK_FEATURES.find(mf => mf.name === f.name)?.id;
+          return mockFeatureId ? featureIds[mockFeatureId] : '';
+        }).filter(Boolean);
+
+        const packageDoc = {
+          ...packageData,
+          featureIds: featureIds_array,
+        };
+
+        const docRef = await addDoc(packagesCol, packageDoc);
+        console.log(`  ✓ Added package: ${pkg.name} (${docRef.id})`);
+      }
+
+      console.log(`\n✓ Imported ${MOCK_PACKAGES.length} packages\n`);
+    } else {
+      console.log(`⚠️  Features collection already has ${existingFeatures.size} documents. Skipping features import.\n`);
+    }
+
+    // Import A La Carte Options
+    console.log('📦 Importing a la carte options...');
+    const alaCarteCol = collection(db, 'ala_carte_options');
+    const existingAlaCarteOptions = await getDocs(alaCarteCol);
+
+    if (existingAlaCarteOptions.empty) {
+      for (const option of MOCK_ALA_CARTE_OPTIONS) {
+        const { id: mockId, ...optionData } = option;
+        const docRef = await addDoc(alaCarteCol, optionData);
+        console.log(`  ✓ Added a la carte: ${option.name} (${docRef.id})`);
+      }
+
+      console.log(`\n✓ Imported ${MOCK_ALA_CARTE_OPTIONS.length} a la carte options\n`);
+    } else {
+      console.log(`⚠️  A la carte collection already has ${existingAlaCarteOptions.size} documents. Skipping import.\n`);
+    }
+
+    console.log('✅ Data import complete!\n');
+    console.log('🌐 Refresh your app to see the data.\n');
+
+  } catch (error) {
+    console.error('❌ Error importing data:', error);
+    process.exit(1);
+  }
+}
+
+importData().then(() => process.exit(0));


### PR DESCRIPTION
- Create import-mock-data.ts script to populate Firestore with mock data
- Add 'import-data' npm script for easy execution
- Install tsx and dotenv dev dependencies for script execution
- Script imports packages, features, and a la carte options to Firestore
- Includes safety checks to avoid duplicate imports