### PR TITLE
fix: restore menu CI and fail closed unsafe GCP builds

### DIFF
--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -12,10 +12,12 @@ This guide provides detailed instructions for deploying the Priority Lexus After
 
 When deploying to Cloud Run with buildpacks (no Dockerfile):
 
-1. Cloud Build runs `npm run gcp-build` which executes `vite build`
+1. Cloud Build runs `npm run gcp-build`, which first requires all six Firebase build variables and then executes `vite build`
 2. During this build step, Vite looks for `VITE_*` environment variables
-3. If these variables are not available, Vite compiles `undefined` into your code
+3. If these variables are not available, `gcp-build` exits before an image can be pushed or deployed
 4. Even if you set runtime environment variables later in Cloud Run, they won't help because the build is already complete
+
+Ordinary `npm run build` remains demo-capable for local development and test automation. The fail-closed requirement is intentionally limited to the buildpack entry point used for GCP production deployments.
 
 ### The Symptom
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:web": "node scripts/run-e2e-webserver.mjs",
     "start": "node index.js",
     "serve": "node index.js",
-    "gcp-build": "npm run build",
+    "gcp-build": "node scripts/validate-env-vars.js --require-firebase && npm run build",
     "prestart": "npm run build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/validate-env-vars.js
+++ b/scripts/validate-env-vars.js
@@ -6,7 +6,7 @@
  * - Missing required variables at build time
  * - Invalid variable formats
  *
- * Usage: node scripts/validate-env-vars.js
+ * Usage: node scripts/validate-env-vars.js [--require-firebase]
  *
  * Exit codes:
  *   0 - All environment variables are valid
@@ -61,11 +61,12 @@ function logInfo(message) {
 /**
  * Validates that environment variable names don't have leading/trailing spaces
  */
-function validateEnvVarNames() {
+function validateEnvVarNames({ rejectRequiredNormalizations = false } = {}) {
   logInfo("Checking for malformed environment variable names...");
   let normalized = 0;
   let detected = 0;
   let collisions = 0;
+  let rejectedRequired = 0;
 
   const envKeys = Object.keys(process.env);
   const normalizations = [];
@@ -83,6 +84,16 @@ function validateEnvVarNames() {
       if (trimmedKey === "") {
         logWarning(
           "Environment variable name consists only of whitespace; ignoring this variable."
+        );
+        return;
+      }
+      if (
+        rejectRequiredNormalizations &&
+        REQUIRED_BUILD_VARS.includes(trimmedKey)
+      ) {
+        rejectedRequired += 1;
+        logError(
+          `Malformed Firebase variable name is not allowed for the GCP production build: "${key}"`
         );
         return;
       }
@@ -131,13 +142,13 @@ function validateEnvVarNames() {
 
   logSuccess("Environment variable name check completed");
 
-  return collisions === 0;
+  return collisions === 0 && rejectedRequired === 0;
 }
 
 /**
  * Validates that required build-time variables are present
  */
-function validateRequiredVars() {
+function validateRequiredVars({ requireAll = false } = {}) {
   logInfo("Checking for required build-time environment variables...");
 
   const missing = [];
@@ -152,9 +163,14 @@ function validateRequiredVars() {
   });
 
   if (missing.length > 0) {
-    logWarning("Missing required environment variables:");
-    missing.forEach((v) => logWarning(`  - ${v}`));
-    logWarning("The app will use mock data in demo mode.");
+    const logMissing = requireAll ? logError : logWarning;
+    logMissing("Missing required environment variables:");
+    missing.forEach((v) => logMissing(`  - ${v}`));
+    if (requireAll) {
+      logError("Firebase configuration is required for the GCP production build.");
+    } else {
+      logWarning("The app will use mock data in demo mode.");
+    }
   }
 
   if (empty.length > 0) {
@@ -170,7 +186,7 @@ function validateRequiredVars() {
     logSuccess("All required environment variables are present");
   }
 
-  return empty.length === 0; // Only fail on empty, not missing (demo mode ok)
+  return empty.length === 0 && (!requireAll || missing.length === 0);
 }
 
 /**
@@ -237,15 +253,17 @@ function validatePort() {
 /**
  * Main validation function
  */
-function main() {
+function main({ requireAll = process.argv.includes("--require-firebase") } = {}) {
   log("\n=== Environment Variable Validation ===\n", "blue");
 
   let allValid = true;
 
   // Run validations
-  if (!validateEnvVarNames()) allValid = false;
+  if (!validateEnvVarNames({ rejectRequiredNormalizations: requireAll })) {
+    allValid = false;
+  }
   if (!validatePort()) allValid = false;
-  if (!validateRequiredVars()) allValid = false;
+  if (!validateRequiredVars({ requireAll })) allValid = false;
   if (!validateEnvVarValues()) allValid = false;
 
   // Summary

--- a/scripts/validate-env-vars.test.ts
+++ b/scripts/validate-env-vars.test.ts
@@ -1,7 +1,36 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { validateEnvVarNames } from "./validate-env-vars.js";
+import { validateEnvVarNames, validateRequiredVars } from "./validate-env-vars.js";
+
+const requiredFirebaseEnv = {
+  VITE_FIREBASE_API_KEY: "test-api-key",
+  VITE_FIREBASE_AUTH_DOMAIN: "test.firebaseapp.com",
+  VITE_FIREBASE_PROJECT_ID: "test-project",
+  VITE_FIREBASE_STORAGE_BUCKET: "test.firebasestorage.app",
+  VITE_FIREBASE_MESSAGING_SENDER_ID: "123456789",
+  VITE_FIREBASE_APP_ID: "1:123456789:web:test",
+};
 
 const cloneEnv = () => ({ ...process.env });
+const validatorPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "validate-env-vars.js"
+);
+
+const runProductionValidator = (firebaseEnv: NodeJS.ProcessEnv) => {
+  const env = { ...process.env };
+
+  for (const key of Object.keys(requiredFirebaseEnv)) {
+    delete env[key];
+  }
+
+  return spawnSync(process.execPath, [validatorPath, "--require-firebase"], {
+    env: { ...env, ...firebaseEnv },
+    encoding: "utf8",
+  });
+};
 
 describe("validate-env-vars normalization", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -61,5 +90,80 @@ describe("validate-env-vars normalization", () => {
     expect(result).toBe(true);
     expect(process.env[""]).toBeUndefined();
     expect(process.env["   "]).toBe("value");
+  });
+});
+
+describe("validate-env-vars production Firebase gate", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = cloneEnv();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("allows missing Firebase variables for ordinary demo-capable builds", () => {
+    process.env = {};
+
+    expect(validateRequiredVars()).toBe(true);
+  });
+
+  it("blocks the GCP production build when any Firebase variable is missing", () => {
+    process.env = { ...requiredFirebaseEnv };
+    delete process.env["VITE_FIREBASE_APP_ID"];
+
+    expect(validateRequiredVars({ requireAll: true })).toBe(false);
+  });
+
+  it("allows the GCP production build when all Firebase variables are present", () => {
+    process.env = { ...requiredFirebaseEnv };
+
+    expect(validateRequiredVars({ requireAll: true })).toBe(true);
+  });
+
+  it("blocks a blank Firebase variable", () => {
+    process.env = { ...requiredFirebaseEnv, VITE_FIREBASE_APP_ID: "   " };
+
+    expect(validateRequiredVars({ requireAll: true })).toBe(false);
+  });
+});
+
+describe("validate-env-vars production CLI", () => {
+  it("exits nonzero when all Firebase variables are missing", () => {
+    const result = runProductionValidator({});
+
+    expect(result.status).toBe(1);
+  });
+
+  it("exits nonzero when a Firebase variable is blank", () => {
+    const result = runProductionValidator({
+      ...requiredFirebaseEnv,
+      VITE_FIREBASE_APP_ID: "   ",
+    });
+
+    expect(result.status).toBe(1);
+  });
+
+  it("exits zero when all six exact Firebase variables are present", () => {
+    const result = runProductionValidator(requiredFirebaseEnv);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("exits nonzero for a whitespace-padded Firebase variable name", () => {
+    const { VITE_FIREBASE_APP_ID: appId, ...fiveExactVariables } =
+      requiredFirebaseEnv;
+    const result = runProductionValidator({
+      ...fiveExactVariables,
+      " VITE_FIREBASE_APP_ID": appId,
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "Malformed Firebase variable name is not allowed"
+    );
   });
 });

--- a/src/components/ProductHub.test.tsx
+++ b/src/components/ProductHub.test.tsx
@@ -253,7 +253,7 @@ describe("ProductHub drag-and-drop interface", () => {
     await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
 
     const pick2EligibleCheckbox = within(card).getByRole("checkbox", { name: /Pick2 Eligible/i });
-    expect(pick2EligibleCheckbox).toBeChecked();
+    await waitFor(() => expect(pick2EligibleCheckbox).toBeChecked());
   });
 
   it("displays unpublished status on card", async () => {

--- a/src/components/ProductHub.test.tsx
+++ b/src/components/ProductHub.test.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   waitFor,
   within,
+  fireEvent,
 } from "../test/test-utils";
 import type { AlaCarteOption, ProductFeature } from "../types";
 
@@ -236,6 +237,23 @@ describe("ProductHub drag-and-drop interface", () => {
     
     const card = findProductCard(feature.name, "packages");
     expect(within(card).getByText("Published")).toBeInTheDocument();
+  });
+
+  it("keeps Pick2 eligible true for the missing-option Pick2 sort admin save path", async () => {
+    const { feature } = await renderHub({ publishToAlaCarte: false, alaCartePrice: 149 });
+
+    const card = findProductCard(feature.name);
+    await userEvent.click(within(card).getByRole("button", { name: /Expand/i }));
+
+    // The sort input is a disabled fallback when Pick2 is unavailable because there is no missing option yet.
+    // Drive it directly to the exact onBlur contract for the missing-option handler.
+    const pick2SortInput = within(card).getByLabelText(/Pick2 Sort/i);
+    fireEvent.blur(pick2SortInput);
+
+    await waitFor(() => expect(mockUpsert).toHaveBeenCalledTimes(1));
+
+    const pick2EligibleCheckbox = within(card).getByRole("checkbox", { name: /Pick2 Eligible/i });
+    expect(pick2EligibleCheckbox).toBeChecked();
   });
 
   it("displays unpublished status on card", async () => {

--- a/src/components/ProductHub.tsx
+++ b/src/components/ProductHub.tsx
@@ -160,12 +160,12 @@ export const ProductHub: React.FC<ProductHubProps> = ({
     [packages]
   );
 
-  const clearRowError = (featureId: string) => {
+  const clearRowError = useCallback((featureId: string) => {
     setRowErrors((prev) => {
       const { [featureId]: _removed, ...rest } = prev;
       return rest;
     });
-  };
+  }, []);
 
   const clearSaved = (featureId: string) => {
     setSavedIds((prev) => {
@@ -196,7 +196,7 @@ export const ProductHub: React.FC<ProductHubProps> = ({
     setRowErrors((prev) => ({ ...prev, [featureId]: message }));
   };
 
-  const markSaved = (featureId: string) => {
+  const markSaved = useCallback((featureId: string) => {
     clearRowError(featureId);
     if (!isMounted.current) return;
     setSavedIds((prev) => {
@@ -217,7 +217,7 @@ export const ProductHub: React.FC<ProductHubProps> = ({
       const { [featureId]: _timer, ...rest } = saveTimers.current;
       saveTimers.current = rest;
     }, 1500);
-  };
+  }, [clearRowError]);
 
   const fetchData = useCallback(async () => {
     if (!db) {
@@ -1324,7 +1324,7 @@ export const ProductHub: React.FC<ProductHubProps> = ({
     try {
       if (!option) {
         if (next) {
-          const resolvedPrice = feature.alaCartePrice ?? option?.price ?? feature.price;
+          const resolvedPrice = feature.alaCartePrice ?? feature.price;
           await upsertAlaCarteFromFeature(
             {
               ...feature,
@@ -1353,14 +1353,13 @@ export const ProductHub: React.FC<ProductHubProps> = ({
       }
       setRowErrorMessage(feature.id, "Failed to save Pick2 Eligible.");
     }
-  }, [requestMenuRefresh]);
+  }, [clearRowError, markSaved, requestMenuRefresh]);
 
   const handlePick2SortBlur = useCallback(async (
     feature: ProductFeature,
     option: AlaCarteOption | undefined,
     raw: string
   ) => {
-    if (!option && !(option?.pick2Eligible ?? false)) return;
     const trimmed = raw.trim();
     const previous = option?.pick2Sort;
 
@@ -1444,14 +1443,13 @@ export const ProductHub: React.FC<ProductHubProps> = ({
       }
       setRowErrorMessage(feature.id, "Failed to save Pick2 Sort.");
     }
-  }, [requestMenuRefresh]);
+  }, [clearRowError, markSaved, requestMenuRefresh]);
 
   const handlePick2ShortValueBlur = useCallback(async (
     feature: ProductFeature,
     option: AlaCarteOption | undefined,
     raw: string
   ) => {
-    if (!option && !(option?.pick2Eligible ?? false)) return;
     const trimmed = raw.trim();
     const next = trimmed ? trimmed : undefined;
     const previous = option?.shortValue;
@@ -1491,7 +1489,7 @@ export const ProductHub: React.FC<ProductHubProps> = ({
       }
       setRowErrorMessage(feature.id, "Failed to save Short Value.");
     }
-  }, [requestMenuRefresh]);
+  }, [clearRowError, markSaved, requestMenuRefresh]);
 
   const handlePick2HighlightsBlur = useCallback(async (
     feature: ProductFeature,
@@ -1499,8 +1497,6 @@ export const ProductHub: React.FC<ProductHubProps> = ({
     line1: string,
     line2: string
   ) => {
-    if (!option && !(option?.pick2Eligible ?? false)) return;
-
     const nextHighlights = [line1.trim(), line2.trim()].filter(Boolean).slice(0, 2);
     const next = nextHighlights.length > 0 ? nextHighlights : undefined;
     const previous = option?.highlights;
@@ -1540,7 +1536,7 @@ export const ProductHub: React.FC<ProductHubProps> = ({
       }
       setRowErrorMessage(feature.id, "Failed to save Highlights.");
     }
-  }, [requestMenuRefresh]);
+  }, [clearRowError, markSaved, requestMenuRefresh]);
 
   const handlePriceInputChange = useCallback((featureId: string, value: string) => {
     setPriceInputs((prev) => ({

--- a/src/components/ProductHub.tsx
+++ b/src/components/ProductHub.tsx
@@ -1384,7 +1384,12 @@ export const ProductHub: React.FC<ProductHubProps> = ({
               pick2Sort: undefined,
             }
           );
-          upsertOptionState(feature, { isPublished: false, price: resolvedPrice, pick2Sort: undefined });
+          upsertOptionState(feature, {
+            isPublished: false,
+            price: resolvedPrice,
+            pick2Eligible: true,
+            pick2Sort: undefined,
+          });
           requestMenuRefresh();
           markSaved(feature.id);
           return;
@@ -1428,7 +1433,12 @@ export const ProductHub: React.FC<ProductHubProps> = ({
             pick2Sort: parsed,
           }
         );
-        upsertOptionState(feature, { isPublished: false, price: resolvedPrice, pick2Sort: parsed });
+        upsertOptionState(feature, {
+          isPublished: false,
+          price: resolvedPrice,
+          pick2Eligible: true,
+          pick2Sort: parsed,
+        });
         requestMenuRefresh();
         markSaved(feature.id);
         return;
@@ -1474,7 +1484,12 @@ export const ProductHub: React.FC<ProductHubProps> = ({
             shortValue: next,
           }
         );
-        upsertOptionState(feature, { isPublished: false, price: resolvedPrice, shortValue: next });
+        upsertOptionState(feature, {
+          isPublished: false,
+          price: resolvedPrice,
+          pick2Eligible: true,
+          shortValue: next,
+        });
         requestMenuRefresh();
         markSaved(feature.id);
         return;
@@ -1521,7 +1536,12 @@ export const ProductHub: React.FC<ProductHubProps> = ({
             highlights: nextHighlights,
           }
         );
-        upsertOptionState(feature, { isPublished: false, price: resolvedPrice, highlights: next });
+        upsertOptionState(feature, {
+          isPublished: false,
+          price: resolvedPrice,
+          pick2Eligible: true,
+          highlights: next,
+        });
         requestMenuRefresh();
         markSaved(feature.id);
         return;

--- a/src/components/product-hub/BulkActionsBar.tsx
+++ b/src/components/product-hub/BulkActionsBar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface BulkActionsBarProps {
-  bulkSelectRef: React.RefObject<HTMLInputElement | null>;
+  bulkSelectRef: React.Ref<HTMLInputElement>;
   allFilteredSelected: boolean;
   selectedCount: number;
   selectedFeatureCount: number;


### PR DESCRIPTION
## Summary

- stabilize Product Hub row-save callbacks and preserve missing-option upserts
- keep Pick 2 optimistic state aligned with persisted `pick2Eligible` values
- align the bulk-selection ref prop with React's input ref contract
- fail closed in `gcp-build` when any required Firebase build variable is missing, blank, or whitespace-misnamed
- keep ordinary local/CI `npm run build` demo-capable

## Verification

- local healthcheck: lint pass, TypeScript pass, 306 unit tests passed / 4 skipped, 30 Chromium tests passed
- production build: pass
- focused production-gate subprocess suite: 12/12 passed
- gate matrix: missing all = blocked; blank = blocked; malformed required name = blocked; six exact dummy values = pass
- hidden Unicode scan: pass
- `git diff --check`: pass
- exact-SHA PR CI: success (run 31767238137)
- exact-SHA manual WebKit/iPad CI: success (run 31767265264)
- independent release audit: PASS after reproducing the production-gate matrix

## Deployment safety

The existing external Google Cloud Build trigger historically executes `npm run gcp-build`. A missing Firebase build configuration now exits during Buildpack before image push or Cloud Run deploy, preventing a demo/mock-mode revision from replacing the authenticated live service.

## Boundaries

- no dependency or lockfile changes
- no Firebase rules, auth, data, secrets, permissions, or GCP trigger configuration changes
- current production remains unchanged until a correctly configured GCP build is available